### PR TITLE
ShipmentType in Shipment model is missing #56

### DIFF
--- a/src/Model/Shipment.php
+++ b/src/Model/Shipment.php
@@ -47,6 +47,13 @@ class Shipment
     public $shippingProductId = 0;
 
     /**
+     * 0 if Shipment, 1 if Retoure
+     * @var int
+     * @DataField(name="ShipmentType", type="int")
+     */
+    public $shipmentType = 0;
+
+    /**
      * Creates a shipment based on models
      *
      * @param ShippingProvider $provider The provider


### PR DESCRIPTION
In this pull request, I added the ShipmentType field to the Shipment Model.