### PR TITLE
Add trigger event

### DIFF
--- a/src/Endpoint/OrdersEndpoint.php
+++ b/src/Endpoint/OrdersEndpoint.php
@@ -476,6 +476,31 @@ class OrdersEndpoint
         );
     }
 
+     /**
+     * Trigger a new event
+     *
+     * @param  int  $orderId The internal id of the order
+     * @param  string  name The name of the event
+     * @param  int  $delayInMinutes Time in minutes by which the event is delayed, default = 0
+     * @return bool True if the event was added
+     *
+     * @throws QuotaExceededException If the maximum number of calls per second exceeded
+     * @throws Exception If the response cannot be parsed
+     */
+    public function triggerEvent(int $orderId, string $name, int $delayInMinutes = 0): bool
+    {
+        $res = $this->client->post(
+            'orders/'.$orderId.'/trigger-event',
+            json_encode([
+                'Name' => $name,
+                'DelayInMinutes' => $delayInMinutes,
+            ]),
+            Response\BaseResponse::class
+        );
+
+        return $res === '' || $res === null;
+    }
+
     #endregion
 
     /** @param mixed $data */

--- a/src/Logger/DiagnosticsLogger.php
+++ b/src/Logger/DiagnosticsLogger.php
@@ -47,55 +47,55 @@ class DiagnosticsLogger implements LoggerInterface
     }
 
     /** @inheritdoc */
-    public function emergency($message, array $context = array())
+    public function emergency(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::EMERGENCY, $message, $context);
     }
 
     /** @inheritdoc */
-    public function alert($message, array $context = array())
+    public function alert(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::ALERT, $message, $context);
     }
 
     /** @inheritdoc */
-    public function critical($message, array $context = array())
+    public function critical(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::CRITICAL, $message, $context);
     }
 
     /** @inheritdoc */
-    public function error($message, array $context = array())
+    public function error(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::ERROR, $message, $context);
     }
 
     /** @inheritdoc */
-    public function warning($message, array $context = array())
+    public function warning(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::WARNING, $message, $context);
     }
 
     /** @inheritdoc */
-    public function notice($message, array $context = array())
+    public function notice(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::NOTICE, $message, $context);
     }
 
     /** @inheritdoc */
-    public function info($message, array $context = array())
+    public function info(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::INFO, $message, $context);
     }
 
     /** @inheritdoc */
-    public function debug($message, array $context = array())
+    public function debug(string|\Stringable $message, array $context = []): void
     {
         $this->log(self::DEBUG, $message, $context);
     }
 
     /** @inheritdoc */
-    public function log($level, $message, array $context = array())
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
         $level = str_pad($level . ':', 10, ' ', STR_PAD_RIGHT);
 

--- a/tests/EchoLogger.php
+++ b/tests/EchoLogger.php
@@ -17,7 +17,7 @@ use Psr\Log\AbstractLogger;
 class EchoLogger extends AbstractLogger
 {
     /** @inheritdoc */
-    public function log($level, $message, array $context = array())
+    public function log($level, \Stringable|string $message, array $context = []):void
     {
         echo sprintf('[%s] %s: %s' . PHP_EOL, date('Y-m-d H:i:s'), strtoupper($level), $message);
         if (!empty($context)) {

--- a/tests/Endpoint/OrdersEndpointTest.php
+++ b/tests/Endpoint/OrdersEndpointTest.php
@@ -459,4 +459,30 @@ class OrdersEndpointTest extends TestCase
         $this->assertSame($model, $data);
         $this->assertSame(GetOrderResponse::class, $class);
     }
+
+    public function testTiggerEvent()
+    {
+        $this->endpoint->triggerEvent(521, 'test-event');
+        $requests = $this->client->getRequests();
+        $this->assertCount(1, $requests);
+
+        list($method, $node, $data, $class) = $requests[0];
+        $this->assertSame('POST', $method);
+        $this->assertSame('orders/521/trigger-event', $node);
+        $this->assertSame('{"Name":"test-event","DelayInMinutes":0}', $data);
+        $this->assertSame(BaseResponse::class, $class);
+    }
+
+    public function testTiggerEventIncludingDelay()
+    {
+        $this->endpoint->triggerEvent(521, 'test-event',1);
+        $requests = $this->client->getRequests();
+        $this->assertCount(1, $requests);
+
+        list($method, $node, $data, $class) = $requests[0];
+        $this->assertSame('POST', $method);
+        $this->assertSame('orders/521/trigger-event', $node);
+        $this->assertSame('{"Name":"test-event","DelayInMinutes":1}', $data);
+        $this->assertSame(BaseResponse::class, $class);
+    }
 }


### PR DESCRIPTION
This pull request adds the triggerEvent function to the order endpoint. It includes two tests:

- testtriggerEvent: tests the call of the new function without a  delay
- testTiggerEventIncludingDelay: tests the call including a delay

The pull request also fix some test issues causes by invalid logger signatures. 